### PR TITLE
Add link to FAQ on main page

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -39,7 +39,7 @@
 			<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 			<img src="/pinestore_cropped.webp" width="128" height="128" alt="store logo" on:click={startRotation} class:rotate={rotateLogo}>
 			<h1>Welcome to Xella's PineStore!</h1>
-			<p>Easily add your ComputerCraft projects, <a href="/projects">browse the tags</a> to check out already uploaded projects and use <a href="/documentation">the API</a> to create your own applications with access to the database!</p>
+			<p>Easily <a href="/faq">add your ComputerCraft projects</a>, <a href="/projects">browse the tags</a> to check out already uploaded projects and use <a href="/documentation">the API</a> to create your own applications with access to the database!</p>
 			<p>Create a CC app to easily install these projects, for e.g. embedding in an OS!</p>
 			<!-- <p>Use the simple CC app, or modify it, embed it into an OS or create your own frontend to easily install projects in Minecraft!</p> -->
 			<!-- <span>Try it out in CC</span>


### PR DESCRIPTION
Before it said you could add projects but didn't explain how. Not much to ask for users to go to the FAQ button at the bottom but it's also kinda easy to miss. Imo it's better to have a link on the main page.