### PR TITLE
fix: Copy-Paste mistake on the auth publishupdate docs page

### DIFF
--- a/src/routes/documentation/[...id]/+page.server.js
+++ b/src/routes/documentation/[...id]/+page.server.js
@@ -741,7 +741,7 @@ The returned JSON object always has a "success" value with an "error" value as a
 			post_params: [
 				{
 					name: "projectId",
-					description: "the id of the project to delete",
+					description: "the id of the project to update",
 				},
 				{
 					name: "body",


### PR DESCRIPTION
Changed "the id of the project to delete" to "the id of the project to update"